### PR TITLE
feat: Paragraph platform integration with wallet-verified authorship

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Inktoll fits into a creator's existing workflow by pulling content directly from
 
 *   🟢 **Ghost (LIVE & Fully Integrated)**: Creators can onboard instantly by pasting their blog URL and Content API Key. Inktoll securely syncs and indexes their feed gaslessly.
 *   🔵 **X (Twitter) (65% Developed - In Progress)**: A strategic roadmap milestone. Utilizing X OAuth 2.0 and X API v2, creators will be able to stitch together their high-value Twitter threads and monetize social media insights for AI agents.
-*   🟡 **WordPress (Coming Soon)**: Integration with the WP REST API v2.
+*   🟢 **Paragraph (LIVE & Fully Integrated)**: Web3-native publishing, home of the former Mirror ecosystem. Creators paste their publication URL — no API key required — and Inktoll verifies authorship cryptographically against the wallet that owns the publication before indexing posts via Paragraph's public content API.
 *   🟡 **Substack (Coming Soon)**: Integration with Substack RSS syndication.
 
 ---

--- a/dashboard/app/creator/dashboard/page.tsx
+++ b/dashboard/app/creator/dashboard/page.tsx
@@ -238,7 +238,16 @@ function CreatorDashboardInner() {
         throw new Error(errData.error || 'Failed to bind wallet');
       }
 
-      showToast('Successfully bound Ghost blog account to your wallet!', 'success');
+      const bindData = await res.json();
+      if (stats?.platform === 'paragraph') {
+        if (bindData.platformVerified) {
+          showToast('Wallet bound — Verified Paragraph Author! Your publication ownership is confirmed onchain.', 'success');
+        } else {
+          showToast('Wallet bound, but this wallet does not own your Paragraph publication. Connect the owning wallet to verify.', 'error');
+        }
+      } else {
+        showToast('Successfully bound Ghost blog account to your wallet!', 'success');
+      }
       await fetchStats();
     } catch (err: any) {
       setError('Binding failed: ' + err.message);
@@ -435,6 +444,11 @@ function CreatorDashboardInner() {
             <div>
               <h1 style={{ margin: 0, fontSize: '2rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
                 Creator Dashboard
+                {stats?.platform === 'paragraph' && stats?.platformVerified && (
+                  <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.3rem', fontSize: '0.7rem', fontWeight: 700, background: 'rgba(52, 211, 153, 0.15)', color: '#10b981', padding: '4px 10px', borderRadius: '999px', verticalAlign: 'middle' }}>
+                    <BadgeCheck size={13} /> VERIFIED PARAGRAPH AUTHOR
+                  </span>
+                )}
               </h1>
               <p style={{ margin: '0.25rem 0 0 0', color: 'var(--text-secondary)' }}>
                 Manage your monetized blog feeds, payouts, and onchain earnings.
@@ -517,6 +531,32 @@ function CreatorDashboardInner() {
             </button>
             </div>
           </div>
+
+          {/* Unverified Paragraph publication nudge */}
+          {stats?.platform === 'paragraph' && !stats?.platformVerified && (
+            <div style={{ padding: '1rem 1.25rem', background: 'var(--primary-glow)', border: '1px solid var(--primary)', borderRadius: '12px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '1rem', flexWrap: 'wrap' }}>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+                <span style={{ fontWeight: 700, color: 'var(--primary)', fontSize: '0.9rem' }}>
+                  ⚠️ Unverified publication
+                </span>
+                <span style={{ fontSize: '0.8rem', color: 'var(--text-secondary)' }}>
+                  {connectedAddress
+                    ? 'Sign with the wallet that owns your Paragraph publication to earn the Verified Author badge.'
+                    : 'Connect the wallet that owns your Paragraph publication (top right), then verify to earn the Verified Author badge.'}
+                </span>
+              </div>
+              {connectedAddress && (
+                <button
+                  className="btn btn-primary"
+                  style={{ padding: '0.5rem 1.25rem', fontSize: '0.8rem', minHeight: 'auto', marginBottom: 0, borderRadius: '8px', whiteSpace: 'nowrap' }}
+                  onClick={handleBindWallet}
+                  disabled={binding}
+                >
+                  {binding ? 'Verifying...' : 'Verify Ownership'}
+                </button>
+              )}
+            </div>
+          )}
 
           {/* Top Row KPI Grid */}
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: '1.5rem' }}>
@@ -727,10 +767,12 @@ function CreatorDashboardInner() {
                 }}>
                   <div style={{ fontWeight: 700, color: 'var(--primary)', display: 'flex', alignItems: 'center', gap: '0.35rem' }}>
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" /><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" /></svg>
-                    Bind Ghost blog to connected wallet
+                    {stats?.platform === 'paragraph' ? 'Bind Paragraph publication to connected wallet' : 'Bind Ghost blog to connected wallet'}
                   </div>
                   <div style={{ color: 'var(--text-secondary)' }}>
-                    Bind your blog account to enable passwordless wallet authentication and secure logins.
+                    {stats?.platform === 'paragraph'
+                      ? 'Binding also verifies publication ownership cryptographically — sign with the wallet that owns your Paragraph account.'
+                      : 'Bind your blog account to enable passwordless wallet authentication and secure logins.'}
                   </div>
                   <button 
                     className="btn btn-primary"

--- a/dashboard/app/creator/onboard/page.tsx
+++ b/dashboard/app/creator/onboard/page.tsx
@@ -8,6 +8,7 @@ export default function CreatorOnboard() {
   const router = useRouter();
   const [ghostUrl, setGhostUrl] = useState('');
   const [ghostApiKey, setGhostApiKey] = useState('');
+  const [paragraphUrl, setParagraphUrl] = useState('');
   const [price, setPrice] = useState('0.005');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
@@ -30,12 +31,21 @@ export default function CreatorOnboard() {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({
-          ghostUrl,
-          ghostApiKey,
-          defaultPriceUsdc: parseFloat(price),
-          ownerAddress
-        }),
+        body: JSON.stringify(
+          selectedPlatform === 'paragraph'
+            ? {
+                platform: 'paragraph',
+                paragraphUrl,
+                defaultPriceUsdc: parseFloat(price),
+                ownerAddress
+              }
+            : {
+                ghostUrl,
+                ghostApiKey,
+                defaultPriceUsdc: parseFloat(price),
+                ownerAddress
+              }
+        ),
       });
 
       if (!response.ok) {
@@ -93,13 +103,18 @@ export default function CreatorOnboard() {
                   <div style={{ fontSize: '0.85rem', color: 'var(--text-muted)' }}>OAuth 2.0 & Stitched Threads</div>
                 </div>
 
-                {/* WordPress Card (Coming Soon) */}
-                <div style={{ padding: '1.5rem', borderRadius: '12px', border: '1px solid var(--border)', background: 'var(--bg-active)', opacity: 0.6, position: 'relative', overflow: 'hidden', cursor: 'not-allowed' }}>
-                  <div style={{ position: 'absolute', top: '12px', right: '12px', background: 'rgba(255, 128, 34, 0.2)', color: 'var(--primary)', padding: '2px 8px', borderRadius: '12px', fontSize: '0.7rem', fontWeight: 'bold' }}>
-                    COMING SOON
+                {/* Paragraph Card (Active) */}
+                <div
+                  onClick={() => setSelectedPlatform('paragraph')}
+                  style={{ padding: '1.5rem', borderRadius: '12px', border: '1px solid var(--primary)', background: 'var(--bg-active)', cursor: 'pointer', transition: 'all 0.2s', boxShadow: '0 4px 20px rgba(255, 128, 34, 0.1)', position: 'relative', overflow: 'hidden' }}
+                  onMouseOver={(e) => e.currentTarget.style.transform = 'translateY(-2px)'}
+                  onMouseOut={(e) => e.currentTarget.style.transform = 'translateY(0)'}
+                >
+                  <div style={{ position: 'absolute', top: '12px', right: '12px', background: 'rgba(52, 211, 153, 0.15)', color: '#10b981', padding: '2px 8px', borderRadius: '12px', fontSize: '0.7rem', fontWeight: 'bold' }}>
+                    LIVE
                   </div>
-                  <div style={{ fontWeight: 'bold', fontSize: '1.2rem', marginBottom: '0.5rem', color: 'var(--text)' }}>WordPress</div>
-                  <div style={{ fontSize: '0.85rem', color: 'var(--text-muted)' }}>WP REST API v2</div>
+                  <div style={{ fontWeight: 'bold', fontSize: '1.2rem', marginBottom: '0.5rem', color: 'var(--text)' }}>Paragraph</div>
+                  <div style={{ fontSize: '0.85rem', color: 'var(--text-muted)' }}>Web3-Native · Wallet Verified</div>
                 </div>
 
                 {/* Substack Card (Coming Soon) */}
@@ -114,18 +129,79 @@ export default function CreatorOnboard() {
               </div>
               
               <div style={{ marginTop: '2rem', textAlign: 'center', fontStyle: 'italic', fontSize: '0.85rem', color: 'var(--text-muted)' }}>
-                For the current hackathon sprint, Ghost is our fully supported integration. We are actively building integrations for X (Twitter), WordPress, and Substack to onboard more creators into the Machine-to-Machine economy.
+                Ghost and Paragraph are our fully supported integrations. We are actively building integrations for X (Twitter) and Substack to onboard more creators into the Machine-to-Machine economy.
               </div>
             </div>
-          ) : (
+          ) : selectedPlatform === 'paragraph' ? (
             <div className="glass-card">
-              <button 
+              <button
                 onClick={() => setSelectedPlatform(null)}
                 style={{ background: 'none', border: 'none', color: 'var(--text-muted)', cursor: 'pointer', marginBottom: '1.5rem', display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: '0.9rem', padding: 0 }}
               >
                 ← Back to Platforms
               </button>
-              
+
+              <h2 style={{ marginBottom: '0.5rem' }}>🖋️ Onboard Your Paragraph Publication</h2>
+              <p style={{ marginBottom: '1.5rem', fontSize: '0.95rem', lineHeight: 1.6 }}>
+                Paste your Paragraph URL — that's it. No API key needed: Paragraph's public content API lets us index your published posts directly, and your authorship is verified cryptographically against the wallet that owns your publication.
+              </p>
+
+              <form onSubmit={handleConnect} style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+                <div className="form-group">
+                  <label className="form-label">Paragraph Publication URL</label>
+                  <input
+                    type="text"
+                    className="form-input"
+                    placeholder="https://paragraph.com/@your-publication"
+                    value={paragraphUrl}
+                    onChange={(e) => setParagraphUrl(e.target.value)}
+                    required
+                  />
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', marginTop: '0.25rem' }}>
+                    <span style={{ fontSize: '0.8rem', color: 'var(--primary)', display: 'flex', alignItems: 'center', gap: '4px' }}>
+                      <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect width="18" height="11" x="3" y="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+                      Also accepts @handle or paragraph.xyz links. Connect the wallet that owns your publication to earn the Verified Author badge.
+                    </span>
+                  </div>
+                </div>
+
+                <div className="form-group">
+                  <label className="form-label">Default Price per Article (USDC)</label>
+                  <input
+                    type="number"
+                    step="0.0001"
+                    min="0.0001"
+                    max="1.0"
+                    className="form-input"
+                    value={price}
+                    onChange={(e) => setPrice(e.target.value)}
+                    required
+                  />
+                  <span style={{ fontSize: '0.8rem', color: 'var(--text-muted)' }}>
+                    Pricing typically ranges from $0.001 to $0.05 USDC per read.
+                  </span>
+                </div>
+
+                {error && (
+                  <div style={{ padding: '1rem', background: 'var(--bg-active)', border: '1px solid var(--primary)', borderRadius: '8px', color: 'var(--primary)', fontSize: '0.9rem' }}>
+                    ⚠️ {error}
+                  </div>
+                )}
+
+                <button type="submit" className="btn btn-primary" disabled={loading}>
+                  {loading ? 'Connecting & Syncing...' : 'Connect Paragraph & Import Posts'}
+                </button>
+              </form>
+            </div>
+          ) : (
+            <div className="glass-card">
+              <button
+                onClick={() => setSelectedPlatform(null)}
+                style={{ background: 'none', border: 'none', color: 'var(--text-muted)', cursor: 'pointer', marginBottom: '1.5rem', display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: '0.9rem', padding: 0 }}
+              >
+                ← Back to Platforms
+              </button>
+
               <h2 style={{ marginBottom: '0.5rem' }}>✍️ Onboard Your Ghost Blog</h2>
               <p style={{ marginBottom: '1.5rem', fontSize: '0.95rem', lineHeight: 1.6 }}>
                 Connect your Ghost publication to start earning USDC. We will generate a Circle Programmable Wallet for you, import your articles, and wrap them with an autonomous x402 paywall.

--- a/dashboard/app/docs/page.tsx
+++ b/dashboard/app/docs/page.tsx
@@ -46,11 +46,11 @@ export default function DocsPage() {
                 <span style={{ color: 'var(--text-secondary)', fontSize: '0.85rem', lineHeight: '1.5', display: 'block' }}>Active milestone. Using X OAuth 2.0 and the X API, creators can import and stitch together high-value Twitter threads, monetizing their social alpha.</span>
               </div>
             </div>
-            <div style={{ display: 'flex', gap: '1rem', background: 'rgba(255,255,255,0.01)', padding: '1rem', borderRadius: '12px', border: '1px solid var(--border)', opacity: 0.6 }}>
-              <span style={{ fontSize: '1.25rem' }}>🟡</span>
+            <div style={{ display: 'flex', gap: '1rem', background: 'rgba(255,255,255,0.01)', padding: '1rem', borderRadius: '12px', border: '1px solid var(--border)' }}>
+              <span style={{ fontSize: '1.25rem' }}>🟢</span>
               <div>
-                <strong style={{ color: 'var(--text-muted)', display: 'block', marginBottom: '0.25rem' }}>WordPress (Coming Soon)</strong>
-                <span style={{ color: 'var(--text-secondary)', fontSize: '0.85rem', lineHeight: '1.5', display: 'block' }}>Integration with the WP REST API v2.</span>
+                <strong style={{ color: 'var(--text-primary)', display: 'block', marginBottom: '0.25rem' }}>Paragraph (LIVE & Integrated)</strong>
+                <span style={{ color: 'var(--text-secondary)', fontSize: '0.85rem', lineHeight: '1.5', display: 'block' }}>Web3-native publishing. Creators paste their publication URL — no API key needed — and authorship is verified cryptographically against the wallet that owns the publication.</span>
               </div>
             </div>
             <div style={{ display: 'flex', gap: '1rem', background: 'rgba(255,255,255,0.01)', padding: '1rem', borderRadius: '12px', border: '1px solid var(--border)', opacity: 0.6 }}>

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -12,6 +12,8 @@ export interface Creator {
   wallet_address: string;
   wallet_id: string;
   default_price_usdc: number;
+  platform?: 'ghost' | 'paragraph';
+  platform_verified?: number;
   created_at: string;
 }
 
@@ -88,6 +90,20 @@ export function initDatabase() {
   try {
     dbInstance.exec("ALTER TABLE creators ADD COLUMN owner_address TEXT");
     console.log("[DB] Added owner_address column to creators table.");
+  } catch (e) {
+    // Column already exists, ignore
+  }
+
+  try {
+    dbInstance.exec("ALTER TABLE creators ADD COLUMN platform TEXT DEFAULT 'ghost'");
+    console.log("[DB] Added platform column to creators table.");
+  } catch (e) {
+    // Column already exists, ignore
+  }
+
+  try {
+    dbInstance.exec("ALTER TABLE creators ADD COLUMN platform_verified INTEGER DEFAULT 0");
+    console.log("[DB] Added platform_verified column to creators table.");
   } catch (e) {
     // Column already exists, ignore
   }

--- a/server/src/routes/creators.ts
+++ b/server/src/routes/creators.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { getDb } from '../db/index.js';
 import { createCircleWallet } from '../services/wallet.js';
 import { fetchGhostArticles } from '../services/ghost.js';
+import { fetchParagraphArticles, verifyParagraphOwnership } from '../services/paragraph.js';
 import crypto from 'crypto';
 import { ethers } from 'ethers';
 import { config } from '../config.js';
@@ -9,17 +10,23 @@ import { config } from '../config.js';
 const router = Router();
 
 router.post('/', async (req, res) => {
-  const { ghostUrl, ghostApiKey, defaultPriceUsdc, ownerAddress } = req.body;
+  const { ghostUrl, ghostApiKey, paragraphUrl, defaultPriceUsdc, ownerAddress } = req.body;
 
-  if (!ghostUrl) {
-    return res.status(400).json({ error: 'ghostUrl is required' });
+  // Platform routing: 'paragraph' publications need only a public URL (no API key);
+  // everything else follows the original Ghost flow. The ghost_url column stores
+  // the source URL for both platforms.
+  const platform = req.body.platform === 'paragraph' || (!ghostUrl && paragraphUrl) ? 'paragraph' : 'ghost';
+  const sourceUrl = platform === 'paragraph' ? paragraphUrl : ghostUrl;
+
+  if (!sourceUrl) {
+    return res.status(400).json({ error: platform === 'paragraph' ? 'paragraphUrl is required' : 'ghostUrl is required' });
   }
 
   const db = getDb();
 
   try {
-    // Generate unique ID based on Ghost URL hash
-    const creatorId = crypto.createHash('md5').update(ghostUrl).digest('hex');
+    // Generate unique ID based on source URL hash
+    const creatorId = crypto.createHash('md5').update(sourceUrl).digest('hex');
 
     // Check if creator already exists
     let creator = db.prepare('SELECT * FROM creators WHERE id = ?').get(creatorId) as any;
@@ -47,28 +54,40 @@ router.post('/', async (req, res) => {
         console.error(`[Creator] Failed to request faucet gas funds:`, faucetErr.message);
       }
 
+      // Paragraph proof-of-authorship: the connected wallet must resolve to the
+      // publication owner via Paragraph's public user API. Non-blocking — an
+      // unverified creator can still onboard, they just don't get the badge.
+      let platformVerified = 0;
+      if (platform === 'paragraph' && ownerAddress) {
+        platformVerified = (await verifyParagraphOwnership(sourceUrl, ownerAddress)) ? 1 : 0;
+      }
+
       // Insert creator
       db.prepare(`
-        INSERT INTO creators (id, ghost_url, ghost_api_key, wallet_address, wallet_id, default_price_usdc, owner_address)
-        VALUES (?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO creators (id, ghost_url, ghost_api_key, wallet_address, wallet_id, default_price_usdc, owner_address, platform, platform_verified)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
       `).run(
         creatorId,
-        ghostUrl,
+        sourceUrl,
         ghostApiKey || '',
         wallet.address,
         wallet.id,
         parseFloat(defaultPriceUsdc || '0.005'),
-        ownerAddress ? ownerAddress.toLowerCase() : null
+        ownerAddress ? ownerAddress.toLowerCase() : null,
+        platform,
+        platformVerified
       );
 
       creator = {
         id: creatorId,
-        ghost_url: ghostUrl,
+        ghost_url: sourceUrl,
         ghost_api_key: ghostApiKey || '',
         wallet_address: wallet.address,
         wallet_id: wallet.id,
         default_price_usdc: parseFloat(defaultPriceUsdc || '0.005'),
         owner_address: ownerAddress ? ownerAddress.toLowerCase() : null,
+        platform,
+        platform_verified: platformVerified,
       };
     } else if (ownerAddress && !creator.owner_address) {
       db.prepare('UPDATE creators SET owner_address = ? WHERE id = ?').run(ownerAddress.toLowerCase(), creatorId);
@@ -76,7 +95,9 @@ router.post('/', async (req, res) => {
     }
 
     // Fetch and import articles
-    const posts = await fetchGhostArticles(ghostUrl, ghostApiKey);
+    const posts = platform === 'paragraph'
+      ? await fetchParagraphArticles(sourceUrl)
+      : await fetchGhostArticles(sourceUrl, ghostApiKey);
     let importedCount = 0;
 
     for (const post of posts) {
@@ -131,6 +152,8 @@ router.post('/', async (req, res) => {
       creatorId: creator.id,
       walletAddress: creator.wallet_address,
       defaultPriceUsdc: creator.default_price_usdc,
+      platform: creator.platform || 'ghost',
+      platformVerified: !!creator.platform_verified,
       articlesImported: importedCount,
       totalArticles: db.prepare('SELECT COUNT(*) as count FROM articles WHERE creator_id = ?').get(creator.id) as any
     });
@@ -255,7 +278,15 @@ router.post('/bind', async (req, res) => {
     // Update owner_address in database
     db.prepare('UPDATE creators SET owner_address = ? WHERE id = ?').run(walletAddress.toLowerCase(), creatorId);
 
-    return res.json({ success: true, ownerAddress: walletAddress.toLowerCase() });
+    // For Paragraph creators, binding a wallet also re-checks cryptographic
+    // proof-of-authorship against the publication owner.
+    let platformVerified = !!creator.platform_verified;
+    if (creator.platform === 'paragraph') {
+      platformVerified = await verifyParagraphOwnership(creator.ghost_url, walletAddress);
+      db.prepare('UPDATE creators SET platform_verified = ? WHERE id = ?').run(platformVerified ? 1 : 0, creatorId);
+    }
+
+    return res.json({ success: true, ownerAddress: walletAddress.toLowerCase(), platformVerified });
   } catch (error: any) {
     console.error(`[Creators Bind] Error: ${error.message}`);
     return res.status(500).json({ error: error.message });
@@ -270,7 +301,9 @@ router.post('/:creatorId/sync', async (req, res) => {
       return res.status(404).json({ error: 'Creator not found' });
     }
 
-    const posts = await fetchGhostArticles(creator.ghost_url, creator.ghost_api_key);
+    const posts = creator.platform === 'paragraph'
+      ? await fetchParagraphArticles(creator.ghost_url)
+      : await fetchGhostArticles(creator.ghost_url, creator.ghost_api_key);
     let importedCount = 0;
 
     for (const post of posts) {
@@ -377,7 +410,7 @@ router.post('/register-agent', (req, res) => {
 
 router.get('/', (req, res) => {
   const db = getDb();
-  const creators = db.prepare('SELECT id, ghost_url, wallet_address, default_price_usdc FROM creators').all();
+  const creators = db.prepare('SELECT id, ghost_url, wallet_address, default_price_usdc, platform FROM creators').all();
   return res.json(creators);
 });
 

--- a/server/src/routes/payments.ts
+++ b/server/src/routes/payments.ts
@@ -79,6 +79,8 @@ router.get('/', async (req, res) => {
         role: 'creator',
         walletAddress: creator.wallet_address,
         ownerAddress: creator.owner_address,
+        platform: creator.platform || 'ghost',
+        platformVerified: !!creator.platform_verified,
         balanceUsdc: balance,
         readCount: readRev.count,
         readRevenueUsdc: readRev.total,

--- a/server/src/services/paragraph.ts
+++ b/server/src/services/paragraph.ts
@@ -4,25 +4,6 @@ import { Article } from '../db/index.js';
 // Docs: https://paragraph.com/docs/api-reference
 const PARAGRAPH_API_BASE = 'https://public.api.paragraph.com/api/v1';
 
-const MOCK_ARTICLES: Partial<Article>[] = [
-  {
-    ghost_slug: 'onchain-writing-economy',
-    title: 'The Onchain Writing Economy After Mirror',
-    excerpt: 'Paragraph absorbed Mirror and became the default home for crypto-native writing. What does that mean for creator monetization?',
-    full_html: `<p>Paragraph absorbed Mirror and became the default home for crypto-native writing. What does that mean for creator monetization?</p>
-<p>Web3 writers already own their audience through wallet subscriptions and permanent storage. The missing piece has been per-read economics: a way for every individual reader — human or AI — to compensate the author directly without a subscription commitment.</p>
-<p>Machine-to-creator nanopayments close that gap. When an AI agent reads an essay and pays USDC for the privilege, the essay stops being marketing and starts being inventory.</p>`,
-  },
-  {
-    ghost_slug: 'wallet-native-authorship',
-    title: 'Wallet-Native Authorship: Proof Without Platforms',
-    excerpt: 'When every writer has a wallet, ownership verification becomes cryptographic instead of bureaucratic.',
-    full_html: `<p>When every writer has a wallet, ownership verification becomes cryptographic instead of bureaucratic.</p>
-<p>Traditional platforms verify authors with API keys, OAuth handshakes, and support tickets. Wallet-native publishing replaces all of that with a signature: prove you control the address that owns the publication, and you have proven authorship.</p>
-<p>This is the foundation for royalty routing — payments can flow to the verified owner with no intermediary custody.</p>`,
-  },
-];
-
 // Accepts "@myblog", "myblog", "https://paragraph.com/@myblog", "paragraph.xyz/@myblog/post" etc.
 export function parseParagraphSlug(input: string): string {
   const trimmed = input.trim().replace(/\/+$/, '');
@@ -65,50 +46,49 @@ async function fetchParagraphPublication(handle: string): Promise<any> {
     // Fall through: some publications use the wallet address as their slug
   }
   const response = await fetch(`${PARAGRAPH_API_BASE}/publications/slug/${encodeURIComponent(handle)}`);
+  if (response.status === 404) {
+    throw new Error(`Paragraph publication '@${handle}' was not found. Double-check your publication URL or handle.`);
+  }
   if (!response.ok) {
-    throw new Error(`Paragraph API responded with status ${response.status} for publication '${handle}'`);
+    throw new Error(`Paragraph API responded with status ${response.status} for publication '${handle}'. Please try again.`);
   }
   return response.json();
 }
 
+// No mock fallback by design: a bad URL or Paragraph API failure must surface
+// to the creator as an error — never silently import sample articles.
 export async function fetchParagraphArticles(publicationUrl: string): Promise<Partial<Article>[]> {
-  if (!publicationUrl || publicationUrl.includes('mock')) {
-    console.log('[Paragraph Service] Running in mock mode, returning sample articles.');
-    return MOCK_ARTICLES;
+  if (!publicationUrl) {
+    throw new Error('Paragraph publication URL is required.');
   }
 
-  try {
-    const slug = parseParagraphSlug(publicationUrl);
-    console.log(`[Paragraph Service] Resolving publication '@${slug}'...`);
-    const publication = await fetchParagraphPublication(slug);
+  const slug = parseParagraphSlug(publicationUrl);
+  console.log(`[Paragraph Service] Resolving publication '@${slug}'...`);
+  const publication = await fetchParagraphPublication(slug);
 
-    const posts: any[] = [];
-    let cursor: string | undefined;
-    do {
-      const params = new URLSearchParams({ limit: '100', includeContent: 'true' });
-      if (cursor) params.set('cursor', cursor);
-      const response = await fetch(`${PARAGRAPH_API_BASE}/publications/${publication.id}/posts?${params}`);
-      if (!response.ok) {
-        throw new Error(`Paragraph API responded with status ${response.status} listing posts`);
-      }
-      const page = (await response.json()) as any;
-      const items = page.items || page.posts || page.data || [];
-      posts.push(...items);
-      cursor = page.hasMore ? page.cursor : undefined;
-    } while (cursor);
+  const posts: any[] = [];
+  let cursor: string | undefined;
+  do {
+    const params = new URLSearchParams({ limit: '100', includeContent: 'true' });
+    if (cursor) params.set('cursor', cursor);
+    const response = await fetch(`${PARAGRAPH_API_BASE}/publications/${publication.id}/posts?${params}`);
+    if (!response.ok) {
+      throw new Error(`Paragraph API responded with status ${response.status} listing posts. Please try again.`);
+    }
+    const page = (await response.json()) as any;
+    const items = page.items || page.posts || page.data || [];
+    posts.push(...items);
+    cursor = page.hasMore ? page.cursor : undefined;
+  } while (cursor);
 
-    console.log(`[Paragraph Service] Fetched ${posts.length} posts from '@${slug}'.`);
-    return posts.map((post: any) => ({
-      ghost_slug: post.slug,
-      title: post.title,
-      excerpt: post.subtitle || '',
-      full_html: post.staticHtml || (post.markdown ? `<pre>${post.markdown}</pre>` : ''),
-      published_at: normalizePublishedAt(post.publishedAt),
-    }));
-  } catch (error: any) {
-    console.error(`[Paragraph Service] Error fetching articles: ${error.message}. Falling back to mock articles.`);
-    return MOCK_ARTICLES;
-  }
+  console.log(`[Paragraph Service] Fetched ${posts.length} posts from '@${slug}'.`);
+  return posts.map((post: any) => ({
+    ghost_slug: post.slug,
+    title: post.title,
+    excerpt: post.subtitle || '',
+    full_html: post.staticHtml || (post.markdown ? `<pre>${post.markdown}</pre>` : ''),
+    published_at: normalizePublishedAt(post.publishedAt),
+  }));
 }
 
 // Cryptographic proof-of-authorship: the connected wallet must resolve (via

--- a/server/src/services/paragraph.ts
+++ b/server/src/services/paragraph.ts
@@ -1,0 +1,135 @@
+import { Article } from '../db/index.js';
+
+// Paragraph public content API — no API key required for reading published content.
+// Docs: https://paragraph.com/docs/api-reference
+const PARAGRAPH_API_BASE = 'https://public.api.paragraph.com/api/v1';
+
+const MOCK_ARTICLES: Partial<Article>[] = [
+  {
+    ghost_slug: 'onchain-writing-economy',
+    title: 'The Onchain Writing Economy After Mirror',
+    excerpt: 'Paragraph absorbed Mirror and became the default home for crypto-native writing. What does that mean for creator monetization?',
+    full_html: `<p>Paragraph absorbed Mirror and became the default home for crypto-native writing. What does that mean for creator monetization?</p>
+<p>Web3 writers already own their audience through wallet subscriptions and permanent storage. The missing piece has been per-read economics: a way for every individual reader — human or AI — to compensate the author directly without a subscription commitment.</p>
+<p>Machine-to-creator nanopayments close that gap. When an AI agent reads an essay and pays USDC for the privilege, the essay stops being marketing and starts being inventory.</p>`,
+  },
+  {
+    ghost_slug: 'wallet-native-authorship',
+    title: 'Wallet-Native Authorship: Proof Without Platforms',
+    excerpt: 'When every writer has a wallet, ownership verification becomes cryptographic instead of bureaucratic.',
+    full_html: `<p>When every writer has a wallet, ownership verification becomes cryptographic instead of bureaucratic.</p>
+<p>Traditional platforms verify authors with API keys, OAuth handshakes, and support tickets. Wallet-native publishing replaces all of that with a signature: prove you control the address that owns the publication, and you have proven authorship.</p>
+<p>This is the foundation for royalty routing — payments can flow to the verified owner with no intermediary custody.</p>`,
+  },
+];
+
+// Accepts "@myblog", "myblog", "https://paragraph.com/@myblog", "paragraph.xyz/@myblog/post" etc.
+export function parseParagraphSlug(input: string): string {
+  const trimmed = input.trim().replace(/\/+$/, '');
+  if (!trimmed.includes('/') && !trimmed.includes('.')) {
+    return trimmed.replace(/^@/, '');
+  }
+  try {
+    const url = new URL(trimmed.startsWith('http') ? trimmed : `https://${trimmed}`);
+    const segments = url.pathname.split('/').filter(Boolean);
+    const handle = segments.find((s) => s.startsWith('@')) || segments[0];
+    if (handle) return handle.replace(/^@/, '');
+  } catch {
+    // Not a parseable URL; fall through to raw handle
+  }
+  return trimmed.replace(/^@/, '');
+}
+
+// Paragraph returns publishedAt as epoch milliseconds; the articles table
+// stores ISO strings (matching the Ghost import path).
+function normalizePublishedAt(value: any): string | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  const date = typeof value === 'number' || /^\d+$/.test(String(value))
+    ? new Date(Number(value))
+    : new Date(value);
+  return isNaN(date.getTime()) ? undefined : date.toISOString();
+}
+
+// Handles both '@slug' handles and wallet-address profile URLs
+// (e.g. app.paragraph.com/0xabc... resolves wallet -> user -> publication).
+async function fetchParagraphPublication(handle: string): Promise<any> {
+  if (/^0x[a-fA-F0-9]{40}$/.test(handle)) {
+    const userResponse = await fetch(`${PARAGRAPH_API_BASE}/users/wallet/${handle}`);
+    if (userResponse.ok) {
+      const user = (await userResponse.json()) as any;
+      if (user.publicationId) {
+        const pubResponse = await fetch(`${PARAGRAPH_API_BASE}/publications/${user.publicationId}`);
+        if (pubResponse.ok) return pubResponse.json();
+      }
+    }
+    // Fall through: some publications use the wallet address as their slug
+  }
+  const response = await fetch(`${PARAGRAPH_API_BASE}/publications/slug/${encodeURIComponent(handle)}`);
+  if (!response.ok) {
+    throw new Error(`Paragraph API responded with status ${response.status} for publication '${handle}'`);
+  }
+  return response.json();
+}
+
+export async function fetchParagraphArticles(publicationUrl: string): Promise<Partial<Article>[]> {
+  if (!publicationUrl || publicationUrl.includes('mock')) {
+    console.log('[Paragraph Service] Running in mock mode, returning sample articles.');
+    return MOCK_ARTICLES;
+  }
+
+  try {
+    const slug = parseParagraphSlug(publicationUrl);
+    console.log(`[Paragraph Service] Resolving publication '@${slug}'...`);
+    const publication = await fetchParagraphPublication(slug);
+
+    const posts: any[] = [];
+    let cursor: string | undefined;
+    do {
+      const params = new URLSearchParams({ limit: '100', includeContent: 'true' });
+      if (cursor) params.set('cursor', cursor);
+      const response = await fetch(`${PARAGRAPH_API_BASE}/publications/${publication.id}/posts?${params}`);
+      if (!response.ok) {
+        throw new Error(`Paragraph API responded with status ${response.status} listing posts`);
+      }
+      const page = (await response.json()) as any;
+      const items = page.items || page.posts || page.data || [];
+      posts.push(...items);
+      cursor = page.hasMore ? page.cursor : undefined;
+    } while (cursor);
+
+    console.log(`[Paragraph Service] Fetched ${posts.length} posts from '@${slug}'.`);
+    return posts.map((post: any) => ({
+      ghost_slug: post.slug,
+      title: post.title,
+      excerpt: post.subtitle || '',
+      full_html: post.staticHtml || (post.markdown ? `<pre>${post.markdown}</pre>` : ''),
+      published_at: normalizePublishedAt(post.publishedAt),
+    }));
+  } catch (error: any) {
+    console.error(`[Paragraph Service] Error fetching articles: ${error.message}. Falling back to mock articles.`);
+    return MOCK_ARTICLES;
+  }
+}
+
+// Cryptographic proof-of-authorship: the connected wallet must resolve (via
+// Paragraph's public user API) to the user who owns the publication.
+export async function verifyParagraphOwnership(publicationUrl: string, walletAddress: string): Promise<boolean> {
+  try {
+    const slug = parseParagraphSlug(publicationUrl);
+    const publication = await fetchParagraphPublication(slug);
+
+    const response = await fetch(`${PARAGRAPH_API_BASE}/users/wallet/${walletAddress}`);
+    if (!response.ok) {
+      console.log(`[Paragraph Service] No Paragraph user found for wallet ${walletAddress} (status ${response.status}).`);
+      return false;
+    }
+    const user = (await response.json()) as any;
+
+    const isOwner = user.id === publication.ownerUserId || user.publicationId === publication.id;
+    console.log(`[Paragraph Service] Ownership check for '@${slug}' vs wallet ${walletAddress}: ${isOwner ? 'VERIFIED' : 'NOT OWNER'}`);
+    return isOwner;
+  } catch (error: any) {
+    console.error(`[Paragraph Service] Ownership verification failed: ${error.message}`);
+    return false;
+  }
+}


### PR DESCRIPTION
## What this adds
Creators can now onboard their **Paragraph** publications (paragraph.com — home of the former Mirror ecosystem) alongside Ghost. Replaces the WordPress "Coming Soon" slot.

### Server
- New `server/src/services/paragraph.ts` using Paragraph's **public content API** (no API key needed):
  - Resolves any URL form: `@handle`, `paragraph.com/@slug`, `paragraph.xyz` links, and wallet-address profile URLs (`app.paragraph.com/0x...`)
  - Imports all published posts with full HTML via cursor pagination; normalizes epoch-ms dates to ISO
  - **Cryptographic proof-of-authorship**: `verifyParagraphOwnership` resolves the connected wallet via Paragraph's user API and confirms it owns the publication
  - **No mock fallback**: bad URLs / API failures throw user-facing errors ("publication not found - double-check your URL") instead of silently importing sample articles
- `creators` routes branch by platform (register, re-sync, bind); bind now re-runs ownership verification for Paragraph creators and returns the verdict
- Safe additive migration: `platform` + `platform_verified` columns on creators (same try/ALTER pattern as existing migrations)
- Creator stats API exposes `platform` / `platformVerified`

### Dashboard
- Onboard page: Paragraph card (LIVE) with a one-field URL form - no API key input
- Creator dashboard: "Unverified publication" banner with a Verify Ownership action, green **VERIFIED PARAGRAPH AUTHOR** badge when confirmed, platform-aware bind panel + toasts
- Docs page + README updated (Paragraph LIVE, WordPress removed)

## Tested against the live Paragraph API
- 46 posts imported from Paragraph's own @blog (pagination + content)
- Real creator account (GSUcoin, wallet-profile URL): post imported with correct HTML/date
- Ownership check: TRUE for the owning wallet, FALSE for a foreign wallet
- Invalid URLs throw the friendly not-found error

## Deploy notes
- Backend restart required (`pm2 restart inktoll-backend`) - server code changed and the DB migration runs at startup
- Migration is additive; existing creators default to platform='ghost'. No data touched.
- After deploy, recommended smoke test: onboard a real Paragraph publication with its owner wallet connected and confirm the Verified badge appears

## Known limitations (accepted)
- Custom-domain Paragraph publications not yet supported (docs note this)
- Creators whose Paragraph wallet is an embedded email wallet can onboard but may not be able to complete verification